### PR TITLE
fix: add index to `tf_key` to avoid duplications

### DIFF
--- a/modules/tf-aws-open-next-zone/main.tf
+++ b/modules/tf-aws-open-next-zone/main.tf
@@ -2,7 +2,7 @@ locals {
   should_create_isr_tag_mapping = var.tag_mapping_db.deployment == "CREATE"
   isr_tag_mapping_file_path     = "${var.folder_path}/dynamodb-provider/dynamodb-cache.json"
   isr_tag_mapping               = local.should_create_isr_tag_mapping && fileexists(local.isr_tag_mapping_file_path) ? jsondecode(file(local.isr_tag_mapping_file_path)) : []
-  isr_tag_mapping_with_tf_key   = [for tag_mapping in local.isr_tag_mapping : merge(tag_mapping, { tf_key = length([for isr_tag_mapping in local.isr_tag_mapping : isr_tag_mapping if isr_tag_mapping.tag.S == tag_mapping.tag.S]) > 1 ? "${tag_mapping.tag.S}-${tag_mapping.path.S}" : tag_mapping.tag.S })]
+  isr_tag_mapping_with_tf_key   = [for tag_mapping in local.isr_tag_mapping : merge(tag_mapping, { tf_key = length([for isr_tag_mapping in local.isr_tag_mapping : isr_tag_mapping if isr_tag_mapping.tag.S == tag_mapping.tag.S]) > 1 ? "${tag_mapping.tag.S}-${count.index}" : tag_mapping.tag.S })]
   isr_tag_mapping_db_name       = local.should_create_isr_tag_mapping ? one(aws_dynamodb_table.isr_table[*].name) : null
   isr_tag_mapping_db_arn        = local.should_create_isr_tag_mapping ? one(aws_dynamodb_table.isr_table[*].arn) : null
 

--- a/modules/tf-aws-open-next-zone/main.tf
+++ b/modules/tf-aws-open-next-zone/main.tf
@@ -2,7 +2,7 @@ locals {
   should_create_isr_tag_mapping = var.tag_mapping_db.deployment == "CREATE"
   isr_tag_mapping_file_path     = "${var.folder_path}/dynamodb-provider/dynamodb-cache.json"
   isr_tag_mapping               = local.should_create_isr_tag_mapping && fileexists(local.isr_tag_mapping_file_path) ? jsondecode(file(local.isr_tag_mapping_file_path)) : []
-  isr_tag_mapping_with_tf_key   = [for tag_mapping in local.isr_tag_mapping : merge(tag_mapping, { tf_key = length([for isr_tag_mapping in local.isr_tag_mapping : isr_tag_mapping if isr_tag_mapping.tag.S == tag_mapping.tag.S]) > 1 ? "${tag_mapping.tag.S}-${count.index}" : tag_mapping.tag.S })]
+  isr_tag_mapping_with_tf_key   = [for tag_mapping in local.isr_tag_mapping : merge(tag_mapping, { tf_key = length([for isr_tag_mapping in local.isr_tag_mapping : isr_tag_mapping if isr_tag_mapping.tag.S == tag_mapping.tag.S]) > 1 ? "${tag_mapping.tag.S}-${tag_mapping.path.S}-${count.index}" : tag_mapping.tag.S })]
   isr_tag_mapping_db_name       = local.should_create_isr_tag_mapping ? one(aws_dynamodb_table.isr_table[*].name) : null
   isr_tag_mapping_db_arn        = local.should_create_isr_tag_mapping ? one(aws_dynamodb_table.isr_table[*].arn) : null
 


### PR DESCRIPTION
I faced the following error, while running the command `terragrunt apply` on [this project](https://github.com/RJPearson94/terraform-aws-open-next-examples/tree/main/single-zone). 

```ts
 Error: Duplicate object key
│
│   on main.tf line 501, in resource "terraform_data" "isr_table_item":
│  501:   for_each = { for item in local.isr_tag_mapping : item.tag.S => item }
│     ├────────────────
│     │ item.tag.S is "6LOfnqfdDQh6Jm_YaQKzS/_N_T_/layout"
│
│ Two different items produced the key "6LOfnqfdDQh6Jm_YaQKzS/_N_T_/layout"
│ in this 'for' expression. If duplicates are expected, use the ellipsis
│ (...) after the value expression to enable grouping by key.
```