### PR TITLE
Allow spaces when syncing objects

### DIFF
--- a/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh
+++ b/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh
@@ -41,7 +41,7 @@ fi
 
 if [ -z "$CACHE_CONTROL" ]
 then 
-    aws s3 cp $SOURCE s3://$BUCKET_NAME/$KEY --cache-control "$CACHE_CONTROL" --content-type "$CONTENT_TYPE"
+    aws s3 cp "$SOURCE" "s3://$BUCKET_NAME/$KEY" --cache-control "$CACHE_CONTROL" --content-type "$CONTENT_TYPE"
 else 
-    aws s3 cp $SOURCE s3://$BUCKET_NAME/$KEY --content-type "$CONTENT_TYPE"
+    aws s3 cp "$SOURCE" "s3://$BUCKET_NAME/$KEY" --content-type "$CONTENT_TYPE"
 fi


### PR DESCRIPTION
Currently if an object has a space in the filename, an error is returned. 

```
│ Error: local-exec provisioner error
│ 
│   with module.single_zone.module.s3_assets.terraform_data.file_sync["fonts/PantographSans-Regular 2.ttf"],
│   on .terraform/modules/single_zone/modules/tf-aws-open-next-s3-assets/main.tf line 57, in resource "terraform_data" "file_sync":
│   57:   provisioner "local-exec" {
│ 
│ Error running command '/bin/bash .terraform/modules/single_zone/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh': exit status 255. Output: .terraform/modules/single_zone/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh: line 16: [:
│ ./<REDACTED>/PantographSans-Regular: binary operator expected
│ .terraform/modules/single_zone/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh: line 26: [: nextjs/assets/fonts/PantographSans-Regular: binary operator expected
``` 

By quoting the strings in the cp command this has been rectified. 