### PR TITLE
Fix revalidation_function reporting a state change

### DIFF
--- a/modules/tf-aws-lambda/main.tf
+++ b/modules/tf-aws-lambda/main.tf
@@ -30,8 +30,12 @@ resource "aws_lambda_function" "lambda_function" {
   layers        = var.layers
   architectures = var.run_at_edge == false ? [var.architecture] : ["x86_64"]
   publish       = var.publish
-  environment {
-    variables = var.environment_variables
+
+  dynamic "environment" {
+    for_each = length(var.environment_variables) > 0 ? [var.environment_variables] : []
+    content {
+      variables = environment.value
+    }
   }
 
   dynamic "tracing_config" {


### PR DESCRIPTION
Terrform reports there is a state change to the revalidation_function when nothing has changed i.e. running Terraform against the same .open-next folder without rebuilding.

The issue stems from the fact that the default environment variables for the revalidation_function is zero in length. When this is the case Terraform trys to create an environment block even though it's empty, reporting a change.

The fix is to convert the environment block to a dynamic block that checks the length of the environment_variables map.

Fixes: #23