### PR TITLE
feat: Add feature to enable the use of CloudFront response headers

### DIFF
--- a/modules/tf-aws-open-next-multi-zone/main.tf
+++ b/modules/tf-aws-open-next-multi-zone/main.tf
@@ -67,6 +67,7 @@ module "public_resources" {
   x_forwarded_host_function = var.distribution.x_forwarded_host_function
   auth_function             = var.distribution.auth_function
   cache_policy              = var.distribution.cache_policy
+  response_headers          = var.distribution.response_headers
 
   behaviours = merge(var.behaviours, {
     static_assets      = var.behaviours.static_assets == null ? local.merged_static_assets : merge(var.behaviours.static_assets, local.merged_static_assets)
@@ -162,7 +163,7 @@ module "website_zone" {
   tag_mapping_db = try(coalesce(each.value.tag_mapping_db, var.tag_mapping_db), null)
 
   website_bucket         = var.deployment != "SHARED_DISTRIBUTION_AND_BUCKET" ? merge(try(coalesce(each.value.website_bucket, var.website_bucket), {}), { deployment = "CREATE", create_bucket_policy = var.deployment == "INDEPENDENT_ZONES" }) : { deployment = "NONE", arn = one(aws_s3_bucket.shared_bucket[*].arn), name = one(aws_s3_bucket.shared_bucket[*].id), region = data.aws_region.current.name, domain_name = one(aws_s3_bucket.shared_bucket[*].bucket_regional_domain_name) }
-  distribution           = var.deployment == "INDEPENDENT_ZONES" ? try(coalesce(each.value.distribution, var.distribution), {}) : { deployment = "NONE", enabled = null, ipv6_enabled = null, http_version = null, price_class = null, geo_restrictions = null, x_forwarded_host_function = null, auth_function = null, lambda_url_oac = null, cache_policy = null }
+  distribution           = var.deployment == "INDEPENDENT_ZONES" ? try(coalesce(each.value.distribution, var.distribution), {}) : { deployment = "NONE", enabled = null, ipv6_enabled = null, http_version = null, price_class = null, geo_restrictions = null, x_forwarded_host_function = null, auth_function = null, lambda_url_oac = null, cache_policy = null, response_headers = null }
   waf                    = try(coalesce(each.value.waf, var.waf), null)
   domain_config          = try(coalesce(each.value.domain_config, var.domain_config), null)
   continuous_deployment  = coalesce(each.value.continuous_deployment, var.continuous_deployment)

--- a/modules/tf-aws-open-next-multi-zone/outputs.tf
+++ b/modules/tf-aws-open-next-multi-zone/outputs.tf
@@ -32,3 +32,7 @@ output "zones" {
     }
   ]
 }
+
+output "response_headers_policy_id" {
+  value = one(module.public_resources[*].response_headers_policy_id)
+}

--- a/modules/tf-aws-open-next-multi-zone/variables.tf
+++ b/modules/tf-aws-open-next-multi-zone/variables.tf
@@ -857,6 +857,58 @@ EOF
       enable_accept_encoding_brotli = optional(bool)
       enable_accept_encoding_gzip   = optional(bool)
     }), {})
+    response_headers = optional(object({
+      deployment = optional(string, "NONE") # NONE, CREATE or USE_EXISTING
+      id         = optional(string)
+      cors_config = optional(object({
+        access_control_allow_credentials = bool
+        access_control_allow_headers     = list(string)
+        access_control_allow_methods     = list(string)
+        access_control_allow_origins     = list(string)
+        access_control_expose_headers    = optional(list(string), [])
+        access_control_max_age_seconds   = optional(number)
+        origin_override                  = bool
+      }))
+      custom_headers_config = optional(list(object({
+        header   = string
+        override = bool
+        value    = string
+      })), [])
+      remove_headers = optional(list(string), [])
+      security_headers_config = optional(object({
+        content_security_policy = optional(object({
+          policy   = string
+          override = bool
+        }))
+        content_type_options = optional(object({
+          override = bool
+        }))
+        frame_options = optional(object({
+          frame_option = string
+          override     = bool
+        }))
+        referrer_policy = optional(object({
+          override = bool
+          policy   = string
+        }))
+        strict_transport_security = optional(object({
+          max_age            = number
+          include_subdomains = optional(bool)
+          override           = bool
+          preload            = optional(bool)
+        }))
+        xss_protection = optional(object({
+          mode_block = optional(bool)
+          override   = bool
+          protection = bool
+          report_url = optional(string)
+        }))
+      }))
+      server_timing_headers_config = optional(object({
+        enabled       = bool
+        sampling_rate = number
+      }))
+    }), {})
   })
   default = {}
 }
@@ -872,12 +924,13 @@ variable "behaviours" {
   type = object({
     custom_error_responses = optional(object({
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -895,12 +948,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -924,12 +978,13 @@ variable "behaviours" {
       paths            = optional(list(string))
       additional_paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -947,12 +1002,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -975,12 +1031,13 @@ variable "behaviours" {
     server = optional(object({
       paths = optional(list(string))
       path_overrides = map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -998,12 +1055,13 @@ variable "behaviours" {
           arn = string
         }))
       }))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -1026,12 +1084,13 @@ variable "behaviours" {
     additional_origins = optional(map(object({
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1049,12 +1108,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -1077,12 +1137,13 @@ variable "behaviours" {
     image_optimisation = optional(object({
       paths = optional(list(string))
       path_overrides = map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1100,12 +1161,13 @@ variable "behaviours" {
           arn = string
         }))
       }))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -1916,12 +1978,13 @@ variable "zones" {
     behaviours = optional(object({
       custom_error_responses = optional(object({
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -1939,12 +2002,13 @@ variable "zones" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1968,12 +2032,13 @@ variable "zones" {
         paths            = optional(list(string))
         additional_paths = optional(list(string))
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -1991,12 +2056,13 @@ variable "zones" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -2019,12 +2085,13 @@ variable "zones" {
       server = optional(object({
         paths = optional(list(string))
         path_overrides = map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -2042,12 +2109,13 @@ variable "zones" {
             arn = string
           }))
         }))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -2070,12 +2138,13 @@ variable "zones" {
       additional_origins = optional(map(object({
         paths = optional(list(string))
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -2093,12 +2162,13 @@ variable "zones" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -2121,12 +2191,13 @@ variable "zones" {
       image_optimisation = optional(object({
         paths = optional(list(string))
         path_overrides = map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -2144,12 +2215,13 @@ variable "zones" {
             arn = string
           }))
         }))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string

--- a/modules/tf-aws-open-next-multi-zone/variables.tf
+++ b/modules/tf-aws-open-next-multi-zone/variables.tf
@@ -901,7 +901,7 @@ EOF
           mode_block = optional(bool)
           override   = bool
           protection = bool
-          report_url = optional(string)
+          report_uri = optional(string)
         }))
       }))
       server_timing_headers_config = optional(object({

--- a/modules/tf-aws-open-next-multi-zone/versions.tf
+++ b/modules/tf-aws-open-next-multi-zone/versions.tf
@@ -9,7 +9,7 @@ terraform {
     aws = {
       source                = "hashicorp/aws"
       version               = ">= 5.46.0"
-      configuration_aliases = [aws.server_function, aws.iam, aws.dns]
+      configuration_aliases = [aws.server_function, aws.iam, aws.dns, aws.global]
     }
     local = {
       source  = "hashicorp/local"

--- a/modules/tf-aws-open-next-public-resources/main.tf
+++ b/modules/tf-aws-open-next-public-resources/main.tf
@@ -9,6 +9,9 @@ locals {
   create_cache_policy = try(var.cache_policy.deployment, "CREATE") == "CREATE"
   cache_policy_id     = local.create_cache_policy ? one(aws_cloudfront_cache_policy.cache_policy[*].id) : try(var.cache_policy.id, null)
 
+  create_response_headers    = try(var.response_headers.deployment, "NONE") == "CREATE"
+  response_headers_policy_id = local.create_response_headers ? one(aws_cloudfront_response_headers_policy.response_headers[*].id) : try(var.response_headers.id, null)
+
   cache_keys = {
     v2 = ["accept", "rsc", "next-router-prefetch", "next-router-state-tree", "next-url", "x-prerender-bypass", "x-prerender-revalidate"]
     v3 = ["x-open-next-cache-key"]
@@ -41,6 +44,8 @@ locals {
         cache_policy_id          = coalesce(try(var.behaviours.custom_error_responses.path_overrides[custom_error_response.path_pattern].cache_policy_id, null), try(var.behaviours.custom_error_responses.cache_policy_id, null), data.aws_cloudfront_cache_policy.caching_optimized.id)
         origin_request_policy_id = try(coalesce(try(var.behaviours.custom_error_responses.path_overrides[custom_error_response.path_pattern].origin_request_policy_id, null), try(var.behaviours.custom_error_responses.origin_request_policy_id, null)), null)
 
+        response_headers_policy_id = try(coalesce(try(var.behaviours.custom_error_responses.path_overrides[custom_error_response.path_pattern].response_headers_policy_id, null), try(var.behaviours.custom_error_responses.response_headers_policy_id, null), local.response_headers_policy_id), null)
+
         compress               = coalesce(try(var.behaviours.custom_error_responses.path_overrides[custom_error_response.path_pattern].compress, null), try(var.behaviours.custom_error_responses.compress, null), true)
         viewer_protocol_policy = coalesce(try(var.behaviours.custom_error_responses.path_overrides[custom_error_response.path_pattern].viewer_protocol_policy, null), try(var.behaviours.custom_error_responses.viewer_protocol_policy, null), "redirect-to-https")
 
@@ -68,6 +73,8 @@ locals {
           cache_policy_id          = coalesce(try(var.behaviours.image_optimisation.path_overrides[image_optimisation_behaviour.formatted].cache_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].path_overrides[image_optimisation_behaviour.original].cache_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].cache_policy_id, null), try(var.behaviours.image_optimisation.cache_policy_id, null), local.cache_policy_id)
           origin_request_policy_id = coalesce(try(var.behaviours.image_optimisation.path_overrides[image_optimisation_behaviour.formatted].origin_request_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].path_overrides[image_optimisation_behaviour.original].origin_request_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].origin_request_policy_id, null), try(var.behaviours.image_optimisation.origin_request_policy_id, null), data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id)
 
+          response_headers_policy_id = try(coalesce(try(var.behaviours.image_optimisation.path_overrides[image_optimisation_behaviour.formatted].response_headers_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].path_overrides[image_optimisation_behaviour.original].response_headers_policy_id, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].response_headers_policy_id, null), try(var.behaviours.image_optimisation.response_headers_policy_id, null), local.response_headers_policy_id), null)
+
           compress               = coalesce(try(var.behaviours.image_optimisation.path_overrides[image_optimisation_behaviour.formatted].compress, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].path_overrides[image_optimisation_behaviour.original].compress, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].compress, null), try(var.behaviours.image_optimisation.compress, null), true)
           viewer_protocol_policy = coalesce(try(var.behaviours.image_optimisation.path_overrides[image_optimisation_behaviour.formatted].viewer_protocol_policy, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].path_overrides[image_optimisation_behaviour.original].viewer_protocol_policy, null), try(var.behaviours.image_optimisation.zone_overrides[zone.name].viewer_protocol_policy, null), try(var.behaviours.image_optimisation.viewer_protocol_policy, null), "redirect-to-https")
 
@@ -91,6 +98,8 @@ locals {
 
           cache_policy_id          = coalesce(try(origin.path_overrides[additional_origin_behaviour].cache_policy_id, null), try(origin.cache_policy_id, null), local.cache_policy_id)
           origin_request_policy_id = coalesce(try(origin.path_overrides[additional_origin_behaviour].origin_request_policy_id, null), try(origin.origin_request_policy_id, null), data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id)
+
+          response_headers_policy_id = try(coalesce(try(origin.path_overrides[additional_origin_behaviour].response_headers_policy_id, null), try(origin.response_headers_policy_id, null), local.response_headers_policy_id), null)
 
           compress               = coalesce(try(origin.path_overrides[additional_origin_behaviour].compress, null), try(origin.compress, null), true)
           viewer_protocol_policy = coalesce(try(origin.path_overrides[additional_origin_behaviour].viewer_protocol_policy, null), try(origin.viewer_protocol_policy, null), "redirect-to-https")
@@ -117,6 +126,8 @@ locals {
           cache_policy_id          = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].cache_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].cache_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].cache_policy_id, null), try(var.behaviours.server.cache_policy_id, null), local.cache_policy_id)
           origin_request_policy_id = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].origin_request_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].origin_request_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].origin_request_policy_id, null), try(var.behaviours.server.origin_request_policy_id, null), data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id)
 
+          response_headers_policy_id = try(coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].response_headers_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].response_headers_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].response_headers_policy_id, null), try(var.behaviours.server.response_headers_policy_id, null), local.response_headers_policy_id), null)
+
           compress               = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].compress, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].compress, null), try(var.behaviours.server.zone_overrides[zone.name].compress, null), try(var.behaviours.server.compress, null), true)
           viewer_protocol_policy = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].viewer_protocol_policy, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].viewer_protocol_policy, null), try(var.behaviours.server.zone_overrides[zone.name].viewer_protocol_policy, null), try(var.behaviours.server.viewer_protocol_policy, null), "redirect-to-https")
 
@@ -140,6 +151,8 @@ locals {
 
           cache_policy_id          = coalesce(try(var.behaviours.static_assets.path_overrides[static_assets_behaviour.formatted].cache_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].path_overrides[static_assets_behaviour.original].cache_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].cache_policy_id, null), try(var.behaviours.static_assets.cache_policy_id, null), data.aws_cloudfront_cache_policy.caching_optimized.id)
           origin_request_policy_id = try(coalesce(try(var.behaviours.static_assets.path_overrides[static_assets_behaviour.formatted].origin_request_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].path_overrides[static_assets_behaviour.original].origin_request_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].origin_request_policy_id, null), try(var.behaviours.static_assets.origin_request_policy_id, null)), null)
+
+          response_headers_policy_id = try(coalesce(try(var.behaviours.static_assets.path_overrides[static_assets_behaviour.formatted].response_headers_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].path_overrides[static_assets_behaviour.original].response_headers_policy_id, null), try(var.behaviours.static_assets.zone_overrides[zone.name].response_headers_policy_id, null), try(var.behaviours.static_assets.response_headers_policy_id, null), local.response_headers_policy_id), null)
 
           compress               = coalesce(try(var.behaviours.static_assets.path_overrides[static_assets_behaviour.formatted].compress, null), try(var.behaviours.static_assets.zone_overrides[zone.name].path_overrides[static_assets_behaviour.original].compress, null), try(var.behaviours.static_assets.zone_overrides[zone.name].compress, null), try(var.behaviours.static_assets.compress, null), true)
           viewer_protocol_policy = coalesce(try(var.behaviours.static_assets.path_overrides[static_assets_behaviour.formatted].viewer_protocol_policy, null), try(var.behaviours.static_assets.zone_overrides[zone.name].path_overrides[static_assets_behaviour.original].viewer_protocol_policy, null), try(var.behaviours.static_assets.zone_overrides[zone.name].viewer_protocol_policy, null), try(var.behaviours.static_assets.viewer_protocol_policy, null), "redirect-to-https")
@@ -165,6 +178,8 @@ locals {
 
           cache_policy_id          = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].cache_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].cache_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].cache_policy_id, null), try(var.behaviours.server.cache_policy_id, null), local.cache_policy_id)
           origin_request_policy_id = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].origin_request_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].origin_request_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].origin_request_policy_id, null), try(var.behaviours.server.origin_request_policy_id, null), data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id)
+
+          response_headers_policy_id = try(coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].response_headers_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].response_headers_policy_id, null), try(var.behaviours.server.zone_overrides[zone.name].response_headers_policy_id, null), try(var.behaviours.server.response_headers_policy_id, null), local.response_headers_policy_id), null)
 
           compress               = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].compress, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].compress, null), try(var.behaviours.server.zone_overrides[zone.name].compress, null), try(var.behaviours.server.compress, null), true)
           viewer_protocol_policy = coalesce(try(var.behaviours.server.path_overrides[server_behaviour.formatted].viewer_protocol_policy, null), try(var.behaviours.server.zone_overrides[zone.name].path_overrides[server_behaviour.original].viewer_protocol_policy, null), try(var.behaviours.server.zone_overrides[zone.name].viewer_protocol_policy, null), try(var.behaviours.server.viewer_protocol_policy, null), "redirect-to-https")
@@ -499,6 +514,145 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
   }
 }
 
+resource "aws_cloudfront_response_headers_policy" "response_headers" {
+  count = var.response_headers.deployment == "DETACH" || local.create_response_headers ? 1 : 0
+  name  = "${local.prefix}response-headers${local.suffix}"
+
+  dynamic "cors_config" {
+    for_each = try(var.response_headers.cors_config, null) != null ? [true] : []
+
+    content {
+      access_control_allow_credentials = try(var.response_headers.cors_config.access_control_allow_credentials, null)
+
+      access_control_allow_headers {
+        items = try(var.response_headers.cors_config.access_control_allow_headers, [])
+      }
+
+      access_control_allow_methods {
+        items = try(var.response_headers.cors_config.access_control_allow_methods, [])
+      }
+
+      access_control_allow_origins {
+        items = try(var.response_headers.cors_config.access_control_allow_origins, [])
+      }
+
+      dynamic "access_control_expose_headers" {
+        for_each = var.response_headers.cors_config.access_control_expose_headers
+
+        content {
+          items = var.response_headers.cors_config.access_control_expose_headers
+        }
+
+      }
+
+      access_control_max_age_sec = try(var.response_headers.cors_config.access_control_max_age_sec, null)
+
+      origin_override = var.response_headers.cors_config.origin_override
+    }
+  }
+
+  dynamic "custom_headers_config" {
+    for_each = try(var.response_headers.custom_headers_config, null) != null ? [true] : []
+
+    content {
+      dynamic "items" {
+        for_each = var.response_headers.custom_headers_config
+
+        content {
+          header   = items.value.header
+          override = items.value.override
+          value    = items.value.value
+        }
+      }
+    }
+  }
+
+  dynamic "remove_headers_config" {
+    for_each = length(var.response_headers.remove_headers) > 0 ? [true] : []
+
+    content {
+      dynamic "items" {
+        for_each = var.response_headers.remove_headers
+
+        content {
+          header = items.value
+        }
+      }
+    }
+  }
+
+  dynamic "security_headers_config" {
+    for_each = try(var.response_headers.security_headers_config, null) != null ? [true] : []
+
+    content {
+      dynamic "content_security_policy" {
+        for_each = try(var.response_headers.security_headers_config.content_security_policy, null) != null ? [var.response_headers.security_headers_config.content_security_policy] : []
+
+        content {
+          content_security_policy = content_security_policy.value.policy
+          override                = content_security_policy.value.override
+        }
+      }
+
+      dynamic "content_type_options" {
+        for_each = try(var.response_headers.security_headers_config.content_type_options, null) != null ? [var.response_headers.security_headers_config.content_type_options] : []
+
+        content {
+          override = content_type_options.value.override
+        }
+      }
+
+      dynamic "frame_options" {
+        for_each = try(var.response_headers.security_headers_config.frame_options, null) != null ? [var.response_headers.security_headers_config.frame_options] : []
+        content {
+          frame_option = frame_options.value.frame_option
+          override     = frame_options.value.override
+        }
+      }
+
+      dynamic "referrer_policy" {
+        for_each = try(var.response_headers.security_headers_config.referrer_policy, null) != null ? [var.response_headers.security_headers_config.referrer_policy] : []
+
+        content {
+          referrer_policy = referrer_policy.value.policy
+          override        = referrer_policy.value.override
+        }
+      }
+
+      dynamic "strict_transport_security" {
+        for_each = try(var.response_headers.security_headers_config.strict_transport_security, null) != null ? [var.response_headers.security_headers_config.strict_transport_security] : []
+
+        content {
+          access_control_max_age_sec = strict_transport_security.value.max_age
+          include_subdomains         = try(strict_transport_security.value.include_subdomains, null)
+          override                   = strict_transport_security.value.override
+          preload                    = try(strict_transport_security.value.preload, null)
+        }
+      }
+
+      dynamic "xss_protection" {
+        for_each = try(var.response_headers.security_headers_config.xss_protection, null) != null ? [var.response_headers.security_headers_config.xss_protection] : []
+
+        content {
+          mode_block = try(xss_protection.value.mode_block)
+          override   = xss_protection.value.override
+          protection = xss_protection.value.protection
+          report_uri = try(xss_protection.value.report_uri, null)
+        }
+      }
+    }
+  }
+
+  dynamic "server_timing_headers_config" {
+    for_each = try(var.response_headers.server_timing_headers_config, null) != null ? [var.response_headers.server_timing_headers_config] : []
+
+    content {
+      enabled       = server_timing_headers_config.value.enabled
+      sampling_rate = server_timing_headers_config.value.sampling_rate
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "website_distribution" {
   count = var.continuous_deployment.use ? 0 : 1
 
@@ -554,6 +708,8 @@ resource "aws_cloudfront_distribution" "website_distribution" {
       cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
       origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
 
+      response_headers_policy_id = ordered_cache_behavior.value.response_headers_policy_id
+
       compress               = ordered_cache_behavior.value.compress
       viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
 
@@ -588,6 +744,8 @@ resource "aws_cloudfront_distribution" "website_distribution" {
 
       cache_policy_id          = default_cache_behavior.value.cache_policy_id
       origin_request_policy_id = default_cache_behavior.value.origin_request_policy_id
+
+      response_headers_policy_id = default_cache_behavior.value.response_headers_policy_id
 
       compress               = default_cache_behavior.value.compress
       viewer_protocol_policy = default_cache_behavior.value.viewer_protocol_policy
@@ -702,6 +860,8 @@ resource "aws_cloudfront_distribution" "production_distribution" {
       cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
       origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
 
+      response_headers_policy_id = ordered_cache_behavior.value.response_headers_policy_id
+
       compress               = ordered_cache_behavior.value.compress
       viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
 
@@ -736,6 +896,8 @@ resource "aws_cloudfront_distribution" "production_distribution" {
 
       cache_policy_id          = default_cache_behavior.value.cache_policy_id
       origin_request_policy_id = default_cache_behavior.value.origin_request_policy_id
+
+      response_headers_policy_id = default_cache_behavior.value.response_headers_policy_id
 
       compress               = default_cache_behavior.value.compress
       viewer_protocol_policy = default_cache_behavior.value.viewer_protocol_policy
@@ -853,6 +1015,8 @@ resource "aws_cloudfront_distribution" "staging_distribution" {
       cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
       origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
 
+      response_headers_policy_id = ordered_cache_behavior.value.response_headers_policy_id
+
       compress               = ordered_cache_behavior.value.compress
       viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
 
@@ -887,6 +1051,8 @@ resource "aws_cloudfront_distribution" "staging_distribution" {
 
       cache_policy_id          = default_cache_behavior.value.cache_policy_id
       origin_request_policy_id = default_cache_behavior.value.origin_request_policy_id
+
+      response_headers_policy_id = default_cache_behavior.value.response_headers_policy_id
 
       compress               = default_cache_behavior.value.compress
       viewer_protocol_policy = default_cache_behavior.value.viewer_protocol_policy

--- a/modules/tf-aws-open-next-public-resources/main.tf
+++ b/modules/tf-aws-open-next-public-resources/main.tf
@@ -624,9 +624,9 @@ resource "aws_cloudfront_response_headers_policy" "response_headers" {
 
         content {
           access_control_max_age_sec = strict_transport_security.value.max_age
-          include_subdomains         = try(strict_transport_security.value.include_subdomains, null)
+          include_subdomains         = strict_transport_security.value.include_subdomains
           override                   = strict_transport_security.value.override
-          preload                    = try(strict_transport_security.value.preload, null)
+          preload                    = strict_transport_security.value.preload
         }
       }
 
@@ -634,10 +634,10 @@ resource "aws_cloudfront_response_headers_policy" "response_headers" {
         for_each = try(var.response_headers.security_headers_config.xss_protection, null) != null ? [var.response_headers.security_headers_config.xss_protection] : []
 
         content {
-          mode_block = try(xss_protection.value.mode_block)
+          mode_block = xss_protection.value.mode_block
           override   = xss_protection.value.override
           protection = xss_protection.value.protection
-          report_uri = try(xss_protection.value.report_uri, null)
+          report_uri = xss_protection.value.report_uri
         }
       }
     }

--- a/modules/tf-aws-open-next-public-resources/main.tf
+++ b/modules/tf-aws-open-next-public-resources/main.tf
@@ -537,12 +537,11 @@ resource "aws_cloudfront_response_headers_policy" "response_headers" {
       }
 
       dynamic "access_control_expose_headers" {
-        for_each = var.response_headers.cors_config.access_control_expose_headers
+        for_each = length(var.response_headers.cors_config.access_control_expose_headers) > 0 ? [true] : []
 
         content {
           items = var.response_headers.cors_config.access_control_expose_headers
         }
-
       }
 
       access_control_max_age_sec = try(var.response_headers.cors_config.access_control_max_age_sec, null)

--- a/modules/tf-aws-open-next-public-resources/outputs.tf
+++ b/modules/tf-aws-open-next-public-resources/outputs.tf
@@ -62,3 +62,7 @@ output "cache_policy_id" {
   description = "The default cache policy ID to associate with the distribution"
   value       = local.cache_policy_id
 }
+
+output "response_headers_policy_id" {
+  value = local.response_headers_policy_id
+}

--- a/modules/tf-aws-open-next-public-resources/variables.tf
+++ b/modules/tf-aws-open-next-public-resources/variables.tf
@@ -151,6 +151,78 @@ variable "cache_policy" {
   }
 }
 
+variable "response_headers" {
+  description = "Configuration for the CloudFront response headers"
+  type = object({
+    deployment = optional(string, "NONE") # NONE, CREATE, USE_EXISTING or DETACH
+    id         = optional(string)
+    cors_config = optional(object({
+      access_control_allow_credentials = bool
+      access_control_allow_headers     = list(string)
+      access_control_allow_methods     = list(string)
+      access_control_allow_origins     = list(string)
+      access_control_expose_headers    = optional(list(string), [])
+      access_control_max_age_seconds   = optional(number)
+      origin_override                  = bool
+    }))
+    custom_headers_config = optional(list(object({
+      header   = string
+      override = bool
+      value    = string
+    })), [])
+    remove_headers = optional(list(string), [])
+    security_headers_config = optional(object({
+      content_security_policy = optional(object({
+        policy   = string
+        override = bool
+      }))
+      content_type_options = optional(object({
+        override = bool
+      }))
+      frame_options = optional(object({
+        frame_option = string
+        override     = bool
+      }))
+      referrer_policy = optional(object({
+        override = bool
+        policy   = string
+      }))
+      strict_transport_security = optional(object({
+        max_age            = number
+        include_subdomains = optional(bool)
+        override           = bool
+        preload            = optional(bool)
+      }))
+      xss_protection = optional(object({
+        mode_block = optional(bool)
+        override   = bool
+        protection = bool
+        report_url = optional(string)
+      }))
+    }))
+    server_timing_headers_config = optional(object({
+      enabled       = bool
+      sampling_rate = number
+    }))
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["NONE", "USE_EXISTING", "CREATE", "DETACH"], var.response_headers.deployment)
+    error_message = "The response headers deployment can be one of NONE, USE_EXISTING, CREATE, or DETACH"
+  }
+
+  validation {
+    condition     = anytrue([contains(["NONE", "CREATE", "DETACH"], var.response_headers.deployment), (var.response_headers.deployment == "USE_EXISTING" && var.response_headers.id != null)])
+    error_message = "The response headers ID must be set when the deployment is set to USE_EXISTING"
+  }
+
+  validation {
+    condition     = anytrue([contains(["NONE", "USE_EXISTING", "DETACH"], var.response_headers.deployment), var.response_headers.deployment == "CREATE" && (var.response_headers.id == null || var.response_headers.id == "")])
+    error_message = "The response headers ID must be null or empty when the deployment is set to CREATE"
+  }
+}
+
 variable "zones" {
   description = "Configuration for the website zones to assoicate with the distribution"
   type = list(object({
@@ -196,12 +268,13 @@ variable "behaviours" {
   type = object({
     custom_error_responses = optional(object({
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -219,12 +292,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -248,12 +322,13 @@ variable "behaviours" {
         paths            = optional(list(string))
         additional_paths = optional(list(string))
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -271,12 +346,13 @@ variable "behaviours" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -298,12 +374,13 @@ variable "behaviours" {
       paths            = optional(list(string))
       additional_paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -321,12 +398,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -349,12 +427,13 @@ variable "behaviours" {
       zone_overrides = optional(map(object({
         paths = optional(list(string))
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -372,12 +451,13 @@ variable "behaviours" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -398,12 +478,13 @@ variable "behaviours" {
       })))
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -421,12 +502,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -448,12 +530,13 @@ variable "behaviours" {
     additional_origins = optional(map(object({
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -471,12 +554,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -499,12 +583,13 @@ variable "behaviours" {
       zone_overrides = optional(map(object({
         paths = optional(list(string))
         path_overrides = optional(map(object({
-          allowed_methods          = optional(list(string))
-          cached_methods           = optional(list(string))
-          cache_policy_id          = optional(string)
-          origin_request_policy_id = optional(string)
-          compress                 = optional(bool)
-          viewer_protocol_policy   = optional(string)
+          allowed_methods            = optional(list(string))
+          cached_methods             = optional(list(string))
+          cache_policy_id            = optional(string)
+          origin_request_policy_id   = optional(string)
+          response_headers_policy_id = optional(string)
+          compress                   = optional(bool)
+          viewer_protocol_policy     = optional(string)
           viewer_request = optional(object({
             type         = string
             arn          = string
@@ -522,12 +607,13 @@ variable "behaviours" {
             arn = string
           }))
         })))
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -548,12 +634,13 @@ variable "behaviours" {
       })))
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -571,12 +658,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string

--- a/modules/tf-aws-open-next-public-resources/variables.tf
+++ b/modules/tf-aws-open-next-public-resources/variables.tf
@@ -197,7 +197,7 @@ variable "response_headers" {
         mode_block = optional(bool)
         override   = bool
         protection = bool
-        report_url = optional(string)
+        report_uri = optional(string)
       }))
     }))
     server_timing_headers_config = optional(object({

--- a/modules/tf-aws-open-next-zone/outputs.tf
+++ b/modules/tf-aws-open-next-zone/outputs.tf
@@ -47,3 +47,7 @@ output "alternate_domain_names" {
   description = "Extra CNAMEs (alternate domain names) associated with the cloudfront distribution"
   value       = local.create_distribution ? one(module.public_resources[*].aliases) : null
 }
+
+output "response_headers_policy_id" {
+  value = one(module.public_resources[*].response_headers_policy_id)
+}

--- a/modules/tf-aws-open-next-zone/variables.tf
+++ b/modules/tf-aws-open-next-zone/variables.tf
@@ -870,6 +870,58 @@ EOF
       enable_accept_encoding_brotli = optional(bool)
       enable_accept_encoding_gzip   = optional(bool)
     }), {})
+    response_headers = optional(object({
+      deployment = optional(string, "NONE") # NONE, CREATE or USE_EXISTING
+      id         = optional(string)
+      cors_config = optional(object({
+        access_control_allow_credentials = bool
+        access_control_allow_headers     = list(string)
+        access_control_allow_methods     = list(string)
+        access_control_allow_origins     = list(string)
+        access_control_expose_headers    = optional(list(string), [])
+        access_control_max_age_seconds   = optional(number)
+        origin_override                  = bool
+      }))
+      custom_headers_config = optional(list(object({
+        header   = string
+        override = bool
+        value    = string
+      })), [])
+      remove_headers = optional(list(string), [])
+      security_headers_config = optional(object({
+        content_security_policy = optional(object({
+          policy   = string
+          override = bool
+        }))
+        content_type_options = optional(object({
+          override = bool
+        }))
+        frame_options = optional(object({
+          frame_option = string
+          override     = bool
+        }))
+        referrer_policy = optional(object({
+          override = bool
+          policy   = string
+        }))
+        strict_transport_security = optional(object({
+          max_age            = number
+          include_subdomains = optional(bool)
+          override           = bool
+          preload            = optional(bool)
+        }))
+        xss_protection = optional(object({
+          mode_block = optional(bool)
+          override   = bool
+          protection = bool
+          report_url = optional(string)
+        }))
+      }))
+      server_timing_headers_config = optional(object({
+        enabled       = bool
+        sampling_rate = number
+      }))
+    }), {})
   })
   default = {}
 }
@@ -879,12 +931,13 @@ variable "behaviours" {
   type = object({
     custom_error_responses = optional(object({
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -902,12 +955,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -931,12 +985,13 @@ variable "behaviours" {
       paths            = optional(list(string))
       additional_paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -954,12 +1009,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -982,12 +1038,13 @@ variable "behaviours" {
     server = optional(object({
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1005,12 +1062,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -1036,12 +1094,13 @@ variable "behaviours" {
       })))
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1059,12 +1118,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string
@@ -1087,12 +1147,13 @@ variable "behaviours" {
     image_optimisation = optional(object({
       paths = optional(list(string))
       path_overrides = optional(map(object({
-        allowed_methods          = optional(list(string))
-        cached_methods           = optional(list(string))
-        cache_policy_id          = optional(string)
-        origin_request_policy_id = optional(string)
-        compress                 = optional(bool)
-        viewer_protocol_policy   = optional(string)
+        allowed_methods            = optional(list(string))
+        cached_methods             = optional(list(string))
+        cache_policy_id            = optional(string)
+        origin_request_policy_id   = optional(string)
+        response_headers_policy_id = optional(string)
+        compress                   = optional(bool)
+        viewer_protocol_policy     = optional(string)
         viewer_request = optional(object({
           type         = string
           arn          = string
@@ -1110,12 +1171,13 @@ variable "behaviours" {
           arn = string
         }))
       })))
-      allowed_methods          = optional(list(string))
-      cached_methods           = optional(list(string))
-      cache_policy_id          = optional(string)
-      origin_request_policy_id = optional(string)
-      compress                 = optional(bool)
-      viewer_protocol_policy   = optional(string)
+      allowed_methods            = optional(list(string))
+      cached_methods             = optional(list(string))
+      cache_policy_id            = optional(string)
+      origin_request_policy_id   = optional(string)
+      response_headers_policy_id = optional(string)
+      compress                   = optional(bool)
+      viewer_protocol_policy     = optional(string)
       viewer_request = optional(object({
         type         = string
         arn          = string

--- a/modules/tf-aws-open-next-zone/variables.tf
+++ b/modules/tf-aws-open-next-zone/variables.tf
@@ -914,7 +914,7 @@ EOF
           mode_block = optional(bool)
           override   = bool
           protection = bool
-          report_url = optional(string)
+          report_uri = optional(string)
         }))
       }))
       server_timing_headers_config = optional(object({


### PR DESCRIPTION
New feature that is disabled by default to enable the use of CloudFront response headers.

@RJPearson94 if you make your terraform-docs config public I'll happily update the README.md files