### PR TITLE
fix: custom_headers_config for_each check

### DIFF
--- a/modules/tf-aws-open-next-public-resources/main.tf
+++ b/modules/tf-aws-open-next-public-resources/main.tf
@@ -551,7 +551,7 @@ resource "aws_cloudfront_response_headers_policy" "response_headers" {
   }
 
   dynamic "custom_headers_config" {
-    for_each = try(var.response_headers.custom_headers_config, null) != null ? [true] : []
+    for_each = length(var.response_headers.custom_headers_config) > 0 ? [true] : []
 
     content {
       dynamic "items" {


### PR DESCRIPTION
This PR fixes a bug in PR #41 where an incorrect check is applied to test if custom_headers_config block should be applied or not. custom_headers_config is a list so a length check should be done.