### PR TITLE
Fix missing auth lambda create, update and delete timeouts

### DIFF
--- a/modules/tf-aws-open-next-public-resources/main.tf
+++ b/modules/tf-aws-open-next-public-resources/main.tf
@@ -454,6 +454,8 @@ module "auth_function" {
     create = false
   }
 
+  timeouts = var.auth_function.timeouts
+
   providers = {
     aws.iam = aws.iam
   }


### PR DESCRIPTION
Whilst destroying my test environment I noticed that the Lambda@Edge Auth function timed out after 10m even though we had set it to 120m, looking at the code for the auth function I noticed that timeouts wasn't defined.

Here is a simple PR to add in the missing timeouts fixing the create, update and delete timeouts.