### PR TITLE
feat: ensure lambda_iam role name is within 64 char limit

### DIFF
--- a/modules/tf-aws-lambda/main.tf
+++ b/modules/tf-aws-lambda/main.tf
@@ -132,8 +132,15 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 
 # IAM
 
+locals {
+  # Ensure IAM role name stays within 64 character limit
+  full_role_name = "${local.prefix}${var.function_name}-role${local.suffix}"
+  # If name exceeds limit, truncate and add a hash suffix for uniqueness
+  role_name = length(local.full_role_name) > 64 ? "${substr(local.full_role_name, 0, 58)}-${substr(sha1(local.full_role_name), 0, 5)}" : local.full_role_name
+}
+
 resource "aws_iam_role" "lambda_iam" {
-  name                 = "${local.prefix}${var.function_name}-role${local.suffix}"
+  name                 = local.role_name
   path                 = try(var.iam.path, null)
   permissions_boundary = try(var.iam.permissions_boundary, null)
 


### PR DESCRIPTION
- Use a hash to ensure the role name is unique if the length is greater than 64

## Explained

### Example 1: Name within limits


If you have:

```
prefix = "prod"
function_name = "api-handler"
suffix = "v1"
```

The full name would be: prod-api-handler-role-v1 (23 characters) Since this is under 64 characters, it would remain unchanged.

### Example 2: Name exceeding limits

If you have:

```
prefix = "prod"
function_name = "prod-open-next-5332123456789-image-optimization-function-role--prod"
suffix = "-prod" # Just an example
```

The full name would be: prod-east-1-very-long-function-name-for-processing-user-authentication-and-authorization-role-lambda-v2 (95 characters)

#### Opennext example

```
prefix = "prod"
function_name = "open-next-5332123456789-image-optimization-function-role"
suffix = "-prod" # Just an example
```

The full name would be: prod-open-next-5332123456789-image-optimization-function-role--prod (64+ characters)

###  Summary

The role name can exceed 64 characters, so truncating and adding a hash suffix should help this (58 characters + 6 character hash = 64 characters)

This approach ensures:

- Names never exceed AWS's 64-character limit
- Truncated names remain unique through the hash suffix
- The most meaningful part of the name (the beginning) is preserved


Let me know what you think