### PR TITLE
expose module.server_function.arn

### DIFF
--- a/modules/tf-aws-open-next-zone/outputs.tf
+++ b/modules/tf-aws-open-next-zone/outputs.tf
@@ -13,6 +13,11 @@ output "bucket_arn" {
   value       = local.should_create_website_bucket ? one(aws_s3_bucket.bucket[*].arn) : null
 }
 
+output "server_function_arn" {
+  description = "The ARN of the default lambda function"
+  value       = module.server_function.arn
+}
+
 output "zone_config" {
   description = "The zone config"
   value       = local.zone


### PR DESCRIPTION
We would like to expose `module.server_function.arn`.
This allows us to use reuse the default lambda function in other aws resources by utilizing terragrunt dependencies.