### PR TITLE
feat: output lambda server function arn

### DIFF
--- a/modules/tf-aws-open-next-zone/outputs.tf
+++ b/modules/tf-aws-open-next-zone/outputs.tf
@@ -13,6 +13,11 @@ output "bucket_arn" {
   value       = local.should_create_website_bucket ? one(aws_s3_bucket.bucket[*].arn) : null
 }
 
+output "server_function_lambda_arn" {
+  description = "The ARN of the server function lambda"
+  value       = module.server_function.arn
+}
+
 output "zone_config" {
   description = "The zone config"
   value       = local.zone


### PR DESCRIPTION
I'd like to be able to reference the lambda ARN where the application code runs in policies.

By having the reference to the arn, I can link it to whatever policies I need.

**Example:**

```
 {
  Sid    = "Allow lambd_server_function_arn access"
  Effect = "Allow"
  Principal = {
    AWS = [
      var.lambda_server_function_arn
    ]
  }
  Action = [
    # ... actions
  ]
  Resource = "*"
},
```
    
**Some notes:**

I didn't apply this same change to the `tf-aws-open-next-multi-zone` as I'm not sure if the arn's for the lambdas would differ depending on the zone (i assume so?)

If we wanted to support that:

```
output "zones" {
  description = "Configuration details of the zones"
  value = [for zone in local.zones : {
    name                               = zone.name
    root                               = zone.root
    path                               = zone.path
    cloudfront_url                     = module.website_zone[zone.name].cloudfront_url
    cloudfront_distribution_id         = module.website_zone[zone.name].cloudfront_distribution_id
    cloudfront_staging_distribution_id = module.website_zone[zone.name].cloudfront_staging_distribution_id
    alternate_domain_names             = module.website_zone[zone.name].alternate_domain_names
    bucket_name                        = module.website_zone[zone.name].bucket_name
     # Add the lambda server function arn here
    }
  ]
}
```

