### PR TITLE
fix: Added missing coalesce on scripts and missing conditional on isr in iam perms

### DIFF
--- a/modules/tf-aws-open-next-s3-assets/main.tf
+++ b/modules/tf-aws-open-next-s3-assets/main.tf
@@ -55,7 +55,7 @@ resource "terraform_data" "file_sync" {
   triggers_replace = [var.zone_suffix, var.s3_path_prefix, each.value.md5]
 
   provisioner "local-exec" {
-    command = "${coalesce(try(var.scripts.file_sync_script.interpreter, var.scripts.interpreter, null), "/bin/bash")} ${try(var.scripts.file_sync_script.path, "${path.module}/scripts/sync-file.sh")}"
+    command = "${coalesce(try(var.scripts.file_sync_script.interpreter, var.scripts.interpreter, null), "/bin/bash")} ${coalesce(try(var.scripts.file_sync_script.path, null), "${path.module}/scripts/sync-file.sh")}"
 
     environment = merge({
       "BUCKET_NAME"   = var.bucket_name

--- a/modules/tf-aws-open-next-zone/main.tf
+++ b/modules/tf-aws-open-next-zone/main.tf
@@ -208,10 +208,10 @@ locals {
       "dynamodb:DeleteItem",
       "dynamodb:DescribeTable",
     ],
-    "Resource" : [
+    "Resource" : local.should_create_isr_tag_mapping? [
       local.isr_tag_mapping_db_arn,
       "${local.isr_tag_mapping_db_arn}/index/*"
-    ],
+    ] : [],
     "Effect" : "Allow"
   }]
 
@@ -843,7 +843,7 @@ resource "terraform_data" "isr_table_item" {
   triggers_replace = [local.staging_alias, md5(jsonencode(each.value))]
 
   provisioner "local-exec" {
-    command = "${coalesce(try(var.scripts.save_item_to_dynamo_script.interpreter, var.scripts.interpreter, null), "/bin/bash")} ${try(var.scripts.save_item_to_dynamo_script.path, "${path.module}/scripts/save-item-to-dynamo.sh")}"
+    command = "${coalesce(try(var.scripts.save_item_to_dynamo_script.interpreter, var.scripts.interpreter, null), "/bin/bash")} ${coalesce(try(var.scripts.save_item_to_dynamo_script.path,null), "${path.module}/scripts/save-item-to-dynamo.sh")}"
 
     environment = merge({
       "TABLE_NAME" = local.isr_tag_mapping_db_name


### PR DESCRIPTION
This caused errors when overriding scripts variable to specify additional environment variables. 
I'm specifying additional_environment_variables to allow specifying temp AWS creds to the scripts as they need to run with different creds to the running environment. 

I also added the check for local. should_create_isr_tag_mapping as without it the iam policy document would error.