### PR TITLE
fix: Set missing `Cache-Control` response headers

### DIFF
--- a/modules/tf-aws-open-next-multi-zone/variables.tf
+++ b/modules/tf-aws-open-next-multi-zone/variables.tf
@@ -140,9 +140,9 @@ variable "aliases" {
 }
 
 variable "cache_control_immutable_assets_regex" {
-  description = "Regex to set public,max-age=31536000,immutable on immutable resources. This can be overridden for each zone"
+  description = "Regex matching content-hashed assets (default: everything under _next/static/, including under a basePath, e.g. docs/_next/static) to set their Cache-Control response header to public,max-age=31536000,immutable. This can be overridden for each zone"
   type        = string
-  default     = "^.*(\\.next)$"
+  default     = "^(?:.*/)?_next/static/.*$"
 }
 
 variable "content_types" {

--- a/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh
+++ b/modules/tf-aws-open-next-s3-assets/scripts/sync-file.sh
@@ -39,9 +39,9 @@ fi
 
 ## Script
 
-if [ -z "$CACHE_CONTROL" ]
-then 
+if [ -n "$CACHE_CONTROL" ]
+then
     aws s3 cp "$SOURCE" "s3://$BUCKET_NAME/$KEY" --cache-control "$CACHE_CONTROL" --content-type "$CONTENT_TYPE"
-else 
+else
     aws s3 cp "$SOURCE" "s3://$BUCKET_NAME/$KEY" --content-type "$CONTENT_TYPE"
 fi

--- a/modules/tf-aws-open-next-s3-assets/variables.tf
+++ b/modules/tf-aws-open-next-s3-assets/variables.tf
@@ -16,9 +16,9 @@ variable "s3_exclusion_regex" {
 }
 
 variable "cache_control_immutable_assets_regex" {
-  description = "Regex to set public,max-age=31536000,immutable on immutable resources"
+  description = "Regex matching content-hashed assets (default: everything under _next/static/, including under a basePath, e.g. docs/_next/static) to set their Cache-Control response header to public,max-age=31536000,immutable"
   type        = string
-  default     = "^.*(\\.next)$"
+  default     = "^(?:.*/)?_next/static/.*$"
 }
 
 variable "force_destroy" {

--- a/modules/tf-aws-open-next-zone/variables.tf
+++ b/modules/tf-aws-open-next-zone/variables.tf
@@ -140,9 +140,9 @@ variable "aliases" {
 }
 
 variable "cache_control_immutable_assets_regex" {
-  description = "Regex to set public,max-age=31536000,immutable on immutable resources"
+  description = "Regex matching content-hashed assets (default: everything under _next/static/, including under a basePath, e.g. docs/_next/static) to set their Cache-Control response header to public,max-age=31536000,immutable"
   type        = string
-  default     = "^.*(\\.next)$"
+  default     = "^(?:.*/)?_next/static/.*$"
 }
 
 variable "content_types" {


### PR DESCRIPTION
## Overview

This PR fixes the issue with assets not being served with `Cache-Control` response headers, but also ensures that content-hashed assets get properly marked as immutable as described [in the Next.js docs](https://nextjs.org/docs/app/guides/cdn-caching#static-assets).

I have a [test repo here](https://github.com/ericvoorhis/cache-control-issue-evidence) where I reproduce the original issue and show the fix side by side.

## Changes
- `sync-file.sh`: Changed `-z` to `-n` on `$CACHE_CONTROL` check so a non-empty `$CACHE_CONTROL` is actually applied (fixes #68).
- `cache_control_immutable_assets_regex` default: `^.*(\\.next)$` changed to `^(?:.*/)?_next/static/.*$` so that hashed `_next/static` assets get marked as immutable. The `^(?:.*/)?` prefix accounts for a configured [basePath](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath).